### PR TITLE
Adding catmandu toolkit

### DIFF
--- a/_data/tools.csv
+++ b/_data/tools.csv
@@ -20,3 +20,4 @@ datapackage-matlab,datapackage (MATLAB),MATLAB,KrisKusano,datapackage,http://www
 json-table,JSON Table,PHP,FootworkSolutions,json_table,,,library,,
 jts-erd,JTS ERD,Python,iburadempa,jts_erd,,Create an ERD for a database given as JSON-table-schema ,library,,
 pg-jts,PG JTS,Python,iburadempa,pg_jts,,Create JSON-table-schema from a live PostgreSQL database ,library,,
+catmandu,Catmandu,Perl,LibreCat,Catmandu,http://librecat.org,ETL tools to transforms JSON/YAML/CSV/RDF/XML/etc,libraray,,

--- a/_data/tools.csv
+++ b/_data/tools.csv
@@ -20,4 +20,4 @@ datapackage-matlab,datapackage (MATLAB),MATLAB,KrisKusano,datapackage,http://www
 json-table,JSON Table,PHP,FootworkSolutions,json_table,,,library,,
 jts-erd,JTS ERD,Python,iburadempa,jts_erd,,Create an ERD for a database given as JSON-table-schema ,library,,
 pg-jts,PG JTS,Python,iburadempa,pg_jts,,Create JSON-table-schema from a live PostgreSQL database ,library,,
-catmandu,Catmandu,Perl,LibreCat,Catmandu,http://librecat.org,ETL tools to transforms JSON/YAML/CSV/RDF/XML/etc,libraray,,
+catmandu,Catmandu,Perl,LibreCat,Catmandu,http://librecat.org,ETL tools to transforms JSON/YAML/CSV/RDF/XML/etc,library,,


### PR DESCRIPTION
Catmandu use Perl library and a command line tool to transform JSON/YAML/XML/RDF and many other formats from/to eachother with help of a data transformation DSL called 'Fix'. For more information see: http://librecat.org
