### PR TITLE
fix old references to Open Data Handbook

### DIFF
--- a/about/edit-site/adding.html
+++ b/about/edit-site/adding.html
@@ -19,7 +19,7 @@ pagination:
 
 <h2>1: Create the page</h2>
 
-<p>First locate the parent directory, or folder, in which your file will live. If you are adding a page to the English language Handbook, for example, you should be in the '<strong>en</strong>' directory, where you’ll see a list of all the Handbook pages.</p>
+<p>First locate the parent directory, or folder, in which your file will live. If you are adding a page to the English language website, for example, you should be in the '<strong>en</strong>' directory, where you’ll see a list of all the website pages.</p>
 
 <p>Above the list of pages is a breadcrumb trail <code>{{ site.github_repo }} / guide / en /</code>, to the right of which is a plus symbol <code><strong>+</strong></code>. Click the plus symbol to create your new page.</p>
 

--- a/about/edit-site/index.html
+++ b/about/edit-site/index.html
@@ -11,7 +11,7 @@ pagination:
 ---
 
 <div class="contributing">
-  <p class="lead">Thank you for your interest in in helping to build The Open Data Handbook. We warmly welcome comments, corrections and additions, as well as suggestions for additional sections and areas to examine. For general discussion about the Handbook, please <a href="{{ site.contact }}" rel="external">get in touch</a>. To jump in with improvements and additions, read on.</p>
+  <p class="lead">Thank you for your interest in in helping to build the frictionlessdata.io website. We warmly welcome comments, corrections and additions, as well as suggestions for additional sections and areas to examine. For general discussion about Frictionless Data, please <a href="{{ site.contact }}" rel="external">get in touch</a>. To jump in with improvements and additions, read on.</p>
 
   <h2>How this site works</h2>
   <p>In order to contribute, you need a little insight of how things work under the hood. We’re not going to go into too much detail here, but the are three components you need some understanding of.</p>


### PR DESCRIPTION
Some pages still mention as if the website was the Open Data Handbook, which this was based upon. They currently show through on the website, whenever you click "Help and instructions" on the right hand menu. This PR changes the reference to mention the frictionlessdata.io website instead.