### PR TITLE
fix for #110 - change the branch the "edit this page" link points to

### DIFF
--- a/_includes/page-tools.html
+++ b/_includes/page-tools.html
@@ -34,7 +34,7 @@
       Improve this page
       
       <span class="tooltip">
-        <a href="https://github.com/{{ site.github_username }}/{{ site.github_repo }}/edit/gh-pages/{{page.path}}" class="github" rel="external">Edit on Github</a>
+        <a href="https://github.com/{{ site.github_username }}/{{ site.github_repo }}/edit/master/{{page.path}}" class="github" rel="external">Edit on Github</a>
         <a href="{{ site.editsitehowto }}" target="_blank">Help and instructions</a>
       </span>
     </li>


### PR DESCRIPTION
I'm assuming here that contributions from people editing through the web interface of Github should go to the master branch of this repository (it was previously pointing to a non-existing gh-pages branch).